### PR TITLE
add commonjs option for external react

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,10 +24,14 @@ module.exports = {
   externals: {
     react: {
       commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'react',
       root: 'React',
     },
     'react-dom': {
       commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      amd: 'react-dom',
       root: 'ReactDOM',
     }
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,14 @@ module.exports = {
     }]
   },
   externals: {
-    react: "React",
-    'react-dom': "ReactDOM"
+    react: {
+      commonjs: 'react',
+      root: 'React',
+    },
+    'react-dom': {
+      commonjs: 'react-dom',
+      root: 'ReactDOM',
+    }
   },
   devServer: {
     contentBase: path.join(__dirname, 'dev-assets'),


### PR DESCRIPTION
We shouldn't force the users to have react globally available, commonjs should be fine too.