### PR TITLE
add basic event mappers

### DIFF
--- a/dev-assets/index.html
+++ b/dev-assets/index.html
@@ -76,7 +76,10 @@
       // if null is returned nothing no DOM event is dispatched
       {
         onClickButton: e => {
-          return null; // don't dispatch more events because click is already bubbling
+          // then `composed` property of click is true, but we don't want it
+          // to bubble into the light DOM, instead we dispatch our own event.
+          e.stopPropagation();
+          return new Event('clickbutton', { bubbles: true }); // don't dispatch more events because click is already bubbling
         },
         onHoverName: e => {
           return new Event('hovername', { bubbles: true });

--- a/dev-assets/index.html
+++ b/dev-assets/index.html
@@ -63,24 +63,33 @@
     // register react component as custom element
     const WRC = WebReactComponents;
     WRC.register(MyComponent, 'my-component', [
-      // these will be json parsed
-      'name',
-      'age',
-      'fruits',
-      'config',
-      // specify a boolean attribute like this
-      '!!isActive',
-      // these will be handlers
-      'onClickButton()',
-      'onHoverName()',
-    ]);
+        // these will be json parsed
+        'name',
+        'age',
+        'fruits',
+        'config',
+        // specify a boolean attribute like this
+        '!!isActive',
+      ],
+      // specify mappers for events, the function receives the arguments
+      // the react handler receives and dispatched an event on the web component
+      // if null is returned nothing no DOM event is dispatched
+      {
+        onClickButton: e => {
+          return null; // don't dispatch more events because click is already bubbling
+        },
+        onHoverName: e => {
+          return new Event('hovername', { bubbles: true });
+        },
+      }
+    );
 
     // add some DOM Level 3 event handlers
     const c = document.getElementById('myComponent');
-    c.addEventListener('onClickButton', function(e) {
+    c.addEventListener('clickbutton', function(e) {
       console.log('Event `onClickButton` triggered', e)
     });
-    c.addEventListener('onHoverName', function(e) {
+    c.addEventListener('hovername', function(e) {
       console.log('Event `onHoverName` triggered', e)
     });
     c.name = 'Fritz';

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,8 @@ const getType = (name) => {
  * @param {string} tagName - A name for the new custom tag
  * @param {string[]} [propNames] - An optional list of property names to be
  * connected with the React component.
+ * @param {Object} [eventMappers] - An optional map of functions which can
+ * return an event to be dispatched
  * @returns {class} - The custom element class
  */
 function register(ReactComponent, tagName, propNames = [], eventMappers = {}) {


### PR DESCRIPTION
Basic implementation of event mappers. This API seems a little better than using functions to redispatch events manually.

- Less boilerplate because the lib is doing the dispatching.
- The function doesn't need the `node` argument anymore
- It's simple: it just gets all arguments passed the handler on the react component would receive and needs to return an event, which is then dispatched on the web component or null , which result in nothing. 
- still gives full control to the user: event cancelation, stopping propagation, using the args, checking the value of `event.composed` etc.